### PR TITLE
fix aggregate regex to handle counts > 10

### DIFF
--- a/tasks/lib/aggregate.js
+++ b/tasks/lib/aggregate.js
@@ -13,7 +13,7 @@ var aggregated = {
  */
 module.exports = function aggregate(data) {
   if (data.indexOf('executed in') > -1) {
-    var matches = data.match(/(\d+) passed.*(\d+) failed.*(\d+) dubious.*(\d+) skipped/);
+    var matches = data.match(/(\d+) passed\D*(\d+) failed\D*(\d+) dubious\D*(\d+) skipped/);
     aggregated.passed += parseInt(matches[1], 10);
     aggregated.failed += parseInt(matches[2], 10);
     aggregated.dubious += parseInt(matches[3], 10);


### PR DESCRIPTION
Greetings,

We noticed that when we had 10 failures in a single suite, casperjs would recognize the failures but wendy would think it had passed.

9 failures would fail and report 9 failures
11 failures would fail but only report 1 failure
10 failures would not fail, would report 0 failures

I tracked it down to the regex in aggregate.js

the ```.*``` was being too greedy and grabbing up all but the last digit the following capture group would get. Changing ```.*``` to ```\D*``` will be greedy only about non-digit characters.

Thanks for the plug-in, it's been very helpful to us!

